### PR TITLE
Create Dockerfile.remote-cpp-env

### DIFF
--- a/Dockerfile.remote-cpp-env
+++ b/Dockerfile.remote-cpp-env
@@ -1,0 +1,43 @@
+# CLion remote docker environment (How to build docker container, run and stop it)
+# Based on https://github.com/JetBrains/clion-remote/blob/master/Dockerfile.remote-cpp-env
+# See https://blog.jetbrains.com/clion/2020/01/using-docker-with-clion/ for context
+#
+# Build and run:
+#   docker build -t clion/remote-cpp-env:<version> -f Dockerfile.remote-cpp-env .
+#   docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:<version>
+#   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
+#
+# stop:
+#   docker stop clion_remote_env
+# 
+# ssh credentials (test user):
+#   user@password 
+
+# use latest supported at the time of writing this dockerfile: bionic
+FROM ubuntu:18.04
+
+RUN apt-get update \
+  && apt-get install -y ssh \
+      build-essential \
+      gcc \
+      g++ \
+      gdb \
+      clang \
+      cmake \
+      rsync \
+      tar \
+      python \
+  && apt-get clean
+
+RUN ( \
+    echo 'LogLevel DEBUG2'; \
+    echo 'PermitRootLogin yes'; \
+    echo 'PasswordAuthentication yes'; \
+    echo 'Subsystem sftp /usr/lib/openssh/sftp-server'; \
+  ) > /etc/ssh/sshd_config_test_clion \
+  && mkdir /run/sshd
+
+RUN useradd -m user \
+  && yes password | passwd user
+
+CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_test_clion"]


### PR DESCRIPTION
Source: https://github.com/JetBrains/clion-remote/blob/master/Dockerfile.remote-cpp-env
Guide: https://blog.jetbrains.com/clion/2020/01/using-docker-with-clion/